### PR TITLE
Added a bins property to Mixin

### DIFF
--- a/cruzdb/models.py
+++ b/cruzdb/models.py
@@ -79,6 +79,15 @@ class Mixin(object):
         return "%s:%i-%i" % (self.chrom, self.start, self.end)
 
     @property
+    def bins(self):
+        bins = [1];
+        for b in range(1 + (start>>26), 1 + ((end-1)>>26)+1):     bins.append(b)
+        for b in range(9 + (start>>23), 9 + ((end-1)>>23)+1):     bins.append(b)
+        for b in range(73 + (start>>20), 73 + ((end-1)>>20)+1):   bins.append(b)
+        for b in range(585 + (start>>17), 585 + ((end-1)>>17)+1): bins.append(b)
+        return set(bins)
+
+    @property
     def introns(self):
         starts, ends = zip(*self.exons)
         return [(e, s) for e, s in zip(ends[:-1], starts[1:])]


### PR DESCRIPTION
Returns a list of bins that should be explored in a SQL join.  I used "set" for the returned list because you can sometimes get the same bin multiple times which will slow down the SQL.  

Also, I ended up using a Python version of Heng Li's code, as this version, despite being harder to understand, is faster than my more explicit loop.
