### PR TITLE
MySQL dialect fix

### DIFF
--- a/cruzdb/__init__.py
+++ b/cruzdb/__init__.py
@@ -69,7 +69,7 @@ class Genome(soup.Genome):
             db = "sqlite:///" + db
 
         # Is this a DB URL? If so, use it directly
-        if self.db_regex.findall(db):
+        if self.db_regex.match(db):
             self.db = self.url = db
             self.dburl = db
             self.user = self.host = self.password = ""


### PR DESCRIPTION
Prior to this patch, Genome defaulted to SQLalchemy dialect defaults when connecting to a database: this meant that MySQLdb was used.
MySQLdb has no Python 3 support, and other alternatives are available, so as a first step this artificial limitation was removed.

Bear in mind that aside from spotting and fixing errors, I cannot run the unit tests as MySQL access is blocked on my network.

This should fix issue #13.
