### PR TITLE
Fix broken link to CruzDB paper in Bioinformatics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 A rendered version of the docs is available at: http://pythonhosted.org/cruzdb/
 
-A paper describing cruzdb is in Bioinformatics: http://bioinformatics.oxfordjournals.org/cgi/content/abstract/btt534?ijkey=9I8rQeolKOhzFHv&keytype=ref
+A paper describing cruzdb is in Bioinformatics: https://doi.org/10.1093/bioinformatics/btt534
 
 cruzdb overview
 ===============


### PR DESCRIPTION
Using DOI links may be longer-lasting than a direct link to the Bioinformatics journal.