### PR TITLE
Replace MySQLdb with pymysql

### DIFF
--- a/cruzdb/__init__.py
+++ b/cruzdb/__init__.py
@@ -9,6 +9,9 @@ import os
 import re
 from sqlalchemy.orm.query import Query
 
+import pymysql
+pymysql.install_as_MySQLdb()
+
 __version__ = "0.5.6"
 
 class BigException(Exception): pass


### PR DESCRIPTION
As MySQLdb is not supported in Python3 and higher version of Python2, I replaced MySQLdb with pymysql.