### PR TITLE
Python 3.x compatibility changes

### DIFF
--- a/cruzdb/__init__.py
+++ b/cruzdb/__init__.py
@@ -2,7 +2,7 @@
 cruzdb: library for pythonic access to UCSC genome-browser's MySQL database
 """
 from __future__ import print_function
-from builtins import int
+from past.builtins import long
 from . import soup
 import six
 import sys

--- a/cruzdb/__init__.py
+++ b/cruzdb/__init__.py
@@ -2,6 +2,7 @@
 cruzdb: library for pythonic access to UCSC genome-browser's MySQL database
 """
 from __future__ import print_function
+from builtins import int
 from . import soup
 import six
 import sys
@@ -394,7 +395,7 @@ class Genome(soup.Genome):
         else:
             chrom = chrom_or_feat
 
-        qstart, qend = long(start), long(end)
+        qstart, qend = int(start), int(end)
         res = self.bin_query(table, chrom, qstart, qend)
 
         i, change = 1, 350

--- a/cruzdb/__init__.py
+++ b/cruzdb/__init__.py
@@ -395,7 +395,7 @@ class Genome(soup.Genome):
         else:
             chrom = chrom_or_feat
 
-        qstart, qend = int(start), int(end)
+        qstart, qend = long(start), long(end)
         res = self.bin_query(table, chrom, qstart, qend)
 
         i, change = 1, 350

--- a/cruzdb/__init__.py
+++ b/cruzdb/__init__.py
@@ -2,10 +2,11 @@
 cruzdb: library for pythonic access to UCSC genome-browser's MySQL database
 """
 from __future__ import print_function
-from past.builtins import long
 from . import soup
 import six
 import sys
+if sys.version_info[0] >= 3:
+    from past.builtins import long
 import os
 import re
 from sqlalchemy.orm.query import Query

--- a/cruzdb/annotate.py
+++ b/cruzdb/annotate.py
@@ -1,6 +1,6 @@
+from __future__ import print_function
 import sys
 import os
-from __future__ import print_function
 from cruzdb.models import Feature, ABase
 from toolshed import reader, nopen
 

--- a/cruzdb/models.py
+++ b/cruzdb/models.py
@@ -48,7 +48,7 @@ def _ncbi_parse(html):
                 pcols.append(cols[-1].split("href=")[1].split(">")[0])
             except IndexError: # no link
                 pcols.append("")
-            yield OrderedDict(zip(colnames, pcols))
+            yield OrderedDict(list(zip(colnames, pcols)))
         except:
             print(record, file=sys.stderr)
 
@@ -63,7 +63,7 @@ class Interval(object):
     ----------
 
     start : int
-    
+
     end : int
 
     chrom : str
@@ -82,9 +82,12 @@ class Interval(object):
         """
         check for overlap with the other interval
         """
-        if self.chrom != other.chrom: return False
-        if self.start >= other.end: return False
-        if other.start >= self.end: return False
+        try:
+            if self.chrom != other.chrom: return False
+            if self.start >= other.end: return False
+            if other.start >= self.end: return False
+        except TypeError:
+            return False
         return True
 
     def is_upstream_of(self, other):
@@ -177,7 +180,7 @@ class ABase(object):
                         in enumerate(self.blockSizes[:-1].decode().split(","))]
 
 
-        return zip(starts, ends)
+        return list(zip(starts, ends))
 
     @property
     def gene_features(self):
@@ -254,9 +257,9 @@ class ABase(object):
         cdsEnd
         """
         # drop the trailing comma
-        starts = (long(s) for s in self.exonStarts[:-1].split(","))
-        ends = (long(s) for s in self.exonEnds[:-1].split(","))
-        return [(s, e) for s, e in zip(starts, ends)
+        starts = (long(s) for s in self.exonStarts[:-1].split(b","))
+        ends = (long(s) for s in self.exonEnds[:-1].split(b","))
+        return [(s, e) for s, e in list(zip(starts, ends))
                                           if e > self.cdsStart and
                                              s < self.cdsEnd]
 
@@ -319,8 +322,8 @@ class ABase(object):
         if not self.is_gene_pred: return []
         se = self.exons
         if not (se or exons) or exons == []: return []
-        starts, ends = zip(*exons) if exons is not None else zip(*se)
-        return [(e, s) for e, s in zip(ends[:-1], starts[1:])]
+        starts, ends = list(zip(*exons)) if exons is not None else list(zip(*se))
+        return [(e, s) for e, s in list(zip(ends[:-1], starts[1:]))]
 
     introns = property(_introns)
 

--- a/cruzdb/models.py
+++ b/cruzdb/models.py
@@ -259,7 +259,7 @@ class ABase(object):
         # drop the trailing comma
         starts = (long(s) for s in self.exonStarts[:-1].split(b","))
         ends = (long(s) for s in self.exonEnds[:-1].split(b","))
-        return [(s, e) for s, e in list(zip(starts, ends))
+        return [(s, e) for s, e in zip(starts, ends)
                                           if e > self.cdsStart and
                                              s < self.cdsEnd]
 
@@ -322,8 +322,8 @@ class ABase(object):
         if not self.is_gene_pred: return []
         se = self.exons
         if not (se or exons) or exons == []: return []
-        starts, ends = list(zip(*exons)) if exons is not None else list(zip(*se))
-        return [(e, s) for e, s in list(zip(ends[:-1], starts[1:]))]
+        starts, ends = zip(*exons) if exons is not None else zip(*se)
+        return [(e, s) for e, s in zip(ends[:-1], starts[1:])]
 
     introns = property(_introns)
 

--- a/cruzdb/soup.py
+++ b/cruzdb/soup.py
@@ -15,7 +15,7 @@ class Genome(sqlsoup.SQLSoup):
         if pids == []:
             pids = [x for x in tbl.columns if any(c in x.name.lower() for c in
                 'chrom start name'.split())]
-        models = __import__("cruzdb.models", globals(), locals(), [], -1).models
+        models = __import__("cruzdb.models", globals(), locals(), []).models
         try:
             base = getattr(models, tablename)
         except AttributeError:

--- a/cruzdb/sqlsoup.py
+++ b/cruzdb/sqlsoup.py
@@ -2,6 +2,7 @@
 
 """
 
+import sys
 from sqlalchemy import Table, MetaData, join
 from sqlalchemy import schema, sql, util
 from sqlalchemy.engine.base import Engine
@@ -10,6 +11,9 @@ from sqlalchemy.orm import scoped_session, sessionmaker, mapper, \
                             object_session, attributes
 from sqlalchemy.orm.interfaces import MapperExtension, EXT_CONTINUE
 from sqlalchemy.sql import expression
+
+if sys.version_info[0] >= 3:
+    basestring = str
 
 __version__ = '0.9.0'
 __all__ = ['SQLSoupError', 'SQLSoup', 'SelectableClassType', 'TableClassType', 'Session']
@@ -127,9 +131,10 @@ def _class_for_table(session, engine, selectable, base_cls, mapper_kwargs):
     selectable = expression._clause_element_as_expr(selectable)
     mapname = _selectable_name(selectable)
     # Py2K
-    if isinstance(mapname, unicode): 
-        engine_encoding = engine.dialect.encoding 
-        mapname = mapname.encode(engine_encoding)
+    if sys.version_info[0] < 3:
+        if isinstance(mapname, unicode):
+            engine_encoding = engine.dialect.encoding
+            mapname = mapname.encode(engine_encoding)
     # end Py2K
 
     if isinstance(selectable, Table):


### PR DESCRIPTION
This fixes most issues with Python 3 compatibility (at least it works for me now on Python 3.7). One thing that remains to be fixed is the in_memory option; either it hangs or it just takes a long time, but in either case this also broke the parallel option, causing it to silently fail and write nothing to the output file. So, now that the parallel option no longer uses the in_memory option it works fine. The changes should also make it work again for comb-p.